### PR TITLE
Add inactive outline colour to config

### DIFF
--- a/scripts/FrameDumps/Extra/author_display_util.py
+++ b/scripts/FrameDumps/Extra/author_display_util.py
@@ -43,18 +43,19 @@ def add_author_display(image, frame_dict, ad_config, main_folder, raw_author_lis
     font_size =  ad_config.getint('font_size')
     font = ImageFont.truetype(os.path.join(font_folder, ad_config.get('font')), font_size)
     active_text_color = common.get_color(ad_config.get('active_text_color'))
-    unactive_text_color = common.get_color(ad_config.get('unactive_text_color'))
+    inactive_text_color = common.get_color(ad_config.get('inactive_text_color'))
     outline_width = ad_config.getint('outline_width')
-    outline_color = common.get_color(ad_config.get('outline_color'))
+    active_outline_color = common.get_color(ad_config.get('active_outline_color'))
+    inactive_outline_color = common.get_color(ad_config.get('inactive_outline_color'))
     curframe = int(frame_dict['frame_of_input'])
     spacing = 4
     current_h = top_left[1]
     
     for author_name in raw_author_list:
         if curframe in author_dict.keys() and author_name in author_dict[curframe]:
-            ID.text( (top_left[0], current_h), author_name, fill = active_text_color, font = font, stroke_width = outline_width, stroke_fill = outline_color)
+            ID.text( (top_left[0], current_h), author_name, fill = active_text_color, font = font, stroke_width = outline_width, stroke_fill = active_outline_color)
         else:
-            ID.text( (top_left[0], current_h), author_name, fill = unactive_text_color , font = font, stroke_width = outline_width, stroke_fill = outline_color)
+            ID.text( (top_left[0], current_h), author_name, fill = inactive_text_color , font = font, stroke_width = outline_width, stroke_fill = inactive_outline_color)
         current_h += spacing + font_size
 
         

--- a/scripts/FrameDumps/Extra/config_util.py
+++ b/scripts/FrameDumps/Extra/config_util.py
@@ -101,6 +101,7 @@ def create_config(filename):
     config.set('Infodisplay', 'show_speed_xyz', 'True')
     config.set('Infodisplay', 'text_speed_xyz', '. Speed')
     config.set('Infodisplay', 'color_speed_xyz', 'FF0000FF')
+
     
     config.set('Infodisplay', '\n#parameters for the XZ speed (delta position)')   
     config.set('Infodisplay', 'show_speed_xz', 'False')
@@ -244,11 +245,13 @@ def create_config(filename):
     config.set('Author display', '\n#color used for the text when the author has input on this frame')
     config.set('Author display', 'active_text_color', 'FFFFFFFF')#
     config.set('Author display', '\n#color used for the text when the author does not have input on this frame')
-    config.set('Author display', 'unactive_text_color', 'FFFFFF80')#
+    config.set('Author display', 'inactive_text_color', 'FFFFFF55')#
     config.set('Author display', '\n#outline width for the font used')
-    config.set('Author display', 'outline_width', '4')#
-    config.set('Author display', '\n#color of the outline width')
-    config.set('Author display', 'outline_color', '000000FF')#
+    config.set('Author display', 'outline_width', '3')#
+    config.set('Author display', '\n#color of the outline when the author has input on this frame')
+    config.set('Author display', 'active_outline_color', '000000FF')#
+    config.set('Author display', '\n#color of the outline when the author has input on this frame')
+    config.set('Author display', 'inactive_outline_color', '00000055')#
     
     with open(filename, 'w') as f:
         config.write(f)


### PR DESCRIPTION
I found it useful to be able to customise this, as it's standard for me to set the entirety of the text to be transparent, rather than just the filled-in portion. I also set the default inactive opacity to 33% (0x55), as that's more standard to what people use.